### PR TITLE
Fixed broken line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a Mod for Farming Simulator 19. It adds shuttle shift, differential lock
 
 **NOTE: The only source of truth is: https://github.com/ZhooL/TSX_EnhancedVehicle. The second valid download location is: https://www.modhoster.de/mods/enhancedvehicle. All other download locations are not validated by me - so handle with care.**
 
-*(c) 2018-2020 by ZhooL. Be so kind to credit me when using this mod or the source code (or parts of it) somewhere.*
+*(c) 2018-2020 by ZhooL. Be so kind to credit me when using this mod or the source code (or parts of it) somewhere.*  
 License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 
 ## Default Keybindings
@@ -44,6 +44,6 @@ License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 * Multi-language support (right now it's a mix of German and English)
 
 # The rest
-**Make Strohablage great again!**
-https://zhool.de
+**Make Strohablage great again!**  
+https://zhool.de  
 https://github.com/ZhooL/TSX_EnhancedVehicle


### PR DESCRIPTION
Previously, the lines were explicitly broken with the HTML `<br>` tags.

Markdown does "support" breaking lines without them, but it's slightly tricky.

On my previous pull request, I accidentally messed up those line breaks by forgetting to add two spaces (`  `) to the end of lines that should be broken.

Now those two extra spaces are there, so line breaks should be there too.

I couldn't tell exactly whether the line breaks would work or not, because I'm editing straight from GitHub, and instead of a live preview, it displays a live diff, and it's tricky to spot that on the diff.

Another thing to note is that some Markdown engines do support line breaks without the extra spaces, as in

```
this is a line
and this is another line
```
> this is a line
> and this is another line

But GitHub's Markdown doesn't, it merges those lines, as in

```
this is a line
and this will get merged on the above line as a single line
```
> this is a line and this will get merged on the above line as a single line

I'm sorry for the inconvenience.